### PR TITLE
Implement Archive command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import seedu.address.commons.util.FileUtil;
+import seedu.address.commons.util.JsonUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.storage.JsonSerializableAddressBook;
+
+/**
+ * Saves a copy of the stored data, into a separate json file.
+ */
+public class ArchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "archive";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Saves a copy of the stored data, "
+            + "into a separate json file\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_ARCHIVE_SUCCESS = "File saved at: ";
+    public static final String MESSAGE_CREATE_FAILURE = "Error in creating file!";
+    public static final String MESSAGE_WRITE_FAILURE = "Error in writing to file!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // Extract the current path and address book.
+        Path currentPath = model.getAddressBookFilePath();
+        ReadOnlyAddressBook currentAddressBook = model.getAddressBook();
+
+        // Generate the new path according to current date and time.
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss.SSSSSS");
+        Path parentPath = currentPath.getParent();
+        String dateTime = LocalDateTime.now().format(formatter);
+        Path suffix = Paths.get(dateTime + ".json");
+        Path newPath = parentPath.resolve(suffix);
+
+        // Create a new .json file based on the new path above.
+        try {
+            FileUtil.createIfMissing(newPath);
+        } catch (IOException e) {
+            throw new CommandException(MESSAGE_CREATE_FAILURE);
+        }
+
+        // Write to the new file that we have created.
+        try {
+            JsonUtil.saveJsonFile(new JsonSerializableAddressBook(currentAddressBook), newPath);
+        } catch (IOException e) {
+            throw new CommandException(MESSAGE_WRITE_FAILURE);
+        }
+
+        return new CommandResult(MESSAGE_ARCHIVE_SUCCESS + newPath.toString());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ArchiveCommand.COMMAND_WORD:
+            return new ArchiveCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Person;
  * An Immutable AddressBook that is serializable to JSON format.
  */
 @JsonRootName(value = "addressbook")
-class JsonSerializableAddressBook {
+public class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;


### PR DESCRIPTION
Implement the archive command, which allows user to "clone" the current .json database into a new .json file (located in the same /data folder).

The output is as follows:
![Capture5](https://user-images.githubusercontent.com/65613207/156922411-db51c5f6-d68c-438b-ab75-a017d8ddb3c2.PNG)

**Note: The Junit test is not ready yet, and can only be implemented after we fix the existing test files. (#35)**
**Will create another issue for this after merging.**