### PR TITLE
Edit add command example

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "John Doe "
             + PREFIX_MODULE_CODE + "CS2103T "
             + PREFIX_PHONE + "98765432 "
-            + PREFIX_TELEGRAM_HANDLE + "john "
+            + PREFIX_TELEGRAM_HANDLE + "johnny "
             + PREFIX_EMAIL + "e0123456@u.nus.edu ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";


### PR DESCRIPTION
The telegram handle field requires a minimum of 5 characters.

![image](https://user-images.githubusercontent.com/46317008/157587073-d95a589a-bd33-48f2-b393-8b8160ea6037.png)

As such, this minor edit to the telegram handle in the `AddCommand` `MESSAGE_USAGE` ensures the given example works without error in TAPA.

Full example command will now be: `add i/A0123456Z n/John Doe m/CS2103T p/98765432 h/johnny e/e0123456@u.nus.edu `