### PR TITLE
Fix bug in list command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -18,6 +19,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.sortFilteredPersonList();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
Bug in current implementation:
List does not work after using the find command.

How to replicate it:
Load TAPA -> Input "find abc" -> Input "list"
{An empty list will be displayed}

**Note: I'm not sure why this fixes it either but I hope I didn't break any feature that was implemented (especially list)**