### PR TITLE
Implement Mark and Unmark command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,28 +126,28 @@ Example:
 
 Marks a specific undone task as done for a particular student.
 
-Format : `mark i/STUDENT_ID UNDONE_TASK_INDEX`
+Format : `mark i/STUDENT_ID idx/UNDONE_TASK_INDEX`
 
 * The undone task corresponding to the index or the particular student will be marked as done in the TAPA.
 * An error message will be displayed to the user if the specified index is a negative number or larger than the number of tasks for that particular student.
 * An error message will be displayed to the user if the task with that specified index for the particular student is already marked as done.
 
 Example:
-* `mark i/AXXXXXXXR 1`
+* `mark i/AXXXXXXXR idx/1`
     * Marks the first undone task for the student with student ID AXXXXXXXR as done.
 
 ### Marking a done task as undone for a student: `unmark`
 
 Marks a specific done task as undone for a particular student.
 
-Format : `unmark i/STUDENT_ID DONE_TASK_INDEX`
+Format : `unmark i/STUDENT_ID idx/DONE_TASK_INDEX`
 
 * The done task corresponding to the index for the particular student will be marked as undone in the TAPA.
 * An error message will be displayed to the user if the specified index is a negative number or larger than the number of tasks for that particular student.
 * An error message will be displayed to the user if the task with that specified index for the particular student is already marked as undone.
 
 Example:
-* `unmark i/AXXXXXXXR 1`
+* `unmark i/AXXXXXXXR idx/1`
     * Marks the first done task for the student with student ID AXXXXXXXR as undone.
 
 ### Editing a student's information: `edit`
@@ -259,8 +259,8 @@ Action      | Format, Examples
 **Manual**  | `manual COMMAND_NAME` <br> e.g., `manual add`
 **Exit**    | `exit`
 **Task**    | `task i/STUDENT_ID` <br> e.g., `task i/AXXXXXXXR`
-**Mark**    | `mark i/STUDENT_ID UNDONE_TASK_INDEX` <br> e.g., `mark i/AXXXXXXXR 1`
-**Unmark**  | `unmark i/STUDENT_ID DONE_TASK_INDEX` <br> e.g., `unmark i/AXXXXXXXR 1`
+**Mark**    | `mark i/STUDENT_ID idx/UNDONE_TASK_INDEX` <br> e.g., `mark i/AXXXXXXXR idx/1`
+**Unmark**  | `unmark i/STUDENT_ID idx/DONE_TASK_INDEX` <br> e.g., `unmark i/AXXXXXXXR idx/1`
 **list**    | `list`
 **Assign**  | `assign i/STUDENT_ID tn/TASK_NAME` <br> e.g., `task i/AXXXXXXXR tn/assignment 1`
 **Edit**    | `edit STUDENT_INDEX [i/MATRICULATION_NO] [n/STUDENT_NAME] [m/MODULE_CODE] [p/PHONE_NUMBER] [t/TELEGRAM_HANDLE] [e/EMAIL_ADDRESS] ` <br> e.g., `edit 10 m/CS2103T p/98765432 t/johnnn e/e0123456@nus.edu.sg`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends Command {
     private final StudentId targetId;
 
     /**
-     * Creates a DeleteCommand to delete the specified {@code Person} using the specfied index.
+     * Creates a DeleteCommand to delete the specified {@code Person} using the specified index.
      */
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
@@ -43,7 +43,7 @@ public class DeleteCommand extends Command {
     }
 
     /**
-     * Creates a DeleteCommand to delete the specified {@code Person} using the specfied student id.
+     * Creates a DeleteCommand to delete the specified {@code Person} using the specified student id.
      */
     public DeleteCommand(StudentId targetId) {
         this.targetId = targetId;

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.StudentId;
+import seedu.address.model.person.exceptions.InvalidTaskIndexException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
+
+/**
+ * Marks a specific undone task as done for a particular student.
+ */
+public class MarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "mark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Marks a specific undone task as done for a particular student. "
+            + "Parameters: STUDENT_ID and INDEX \n"
+            + "Example: " + COMMAND_WORD + PREFIX_ID + "A0123456Z" + PREFIX_INDEX + "1";
+
+    public static final String MARKED_TASK_SUCCESS = "Task for %1$s marked";
+
+    private final StudentId studentId;
+    private final Index index;
+
+    /**
+     * Creates a MarkCommand to mark the {@code Task} of the specified {@code Person} using the specified index.
+     */
+    public MarkCommand(StudentId studentId, Index index) {
+        requireNonNull(studentId);
+        requireNonNull(index);
+
+        this.studentId = studentId;
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+
+        try {
+            requireNonNull(model);
+            model.markTaskOfPerson(studentId, index);
+        } catch (InvalidTaskIndexException invalidTaskIndexException) {
+            throw new InvalidTaskIndexException();
+        } catch (TaskAlreadyCompleteException taskAlreadyCompleteException) {
+            throw new TaskAlreadyCompleteException();
+        } catch (PersonNotFoundException personNotFoundException) {
+            throw new PersonNotFoundException();
+        } finally {
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        }
+
+        return new CommandResult(String.format(MARKED_TASK_SUCCESS, studentId));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -12,28 +12,26 @@ import seedu.address.model.person.StudentId;
 import seedu.address.model.person.exceptions.InvalidTaskIndexException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
+import seedu.address.model.person.exceptions.TaskAlreadyNotCompleteException;
 
-/**
- * Marks a specific undone task as done for a particular student.
- */
-public class MarkCommand extends Command {
+public class UnmarkCommand extends Command {
 
-    public static final String COMMAND_WORD = "mark";
+    public static final String COMMAND_WORD = "unmark";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Marks a specific undone task as done for a particular student. "
+            + ": Marks a specific done task as undone for a particular student. "
             + "Parameters: STUDENT_ID and INDEX \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z " + PREFIX_INDEX + "1";
 
-    public static final String MARKED_TASK_SUCCESS = "Task for %1$s marked";
+    public static final String MARKED_TASK_SUCCESS = "Task for %1$s unmarked";
 
     private final StudentId studentId;
     private final Index index;
 
     /**
-     * Creates a MarkCommand to mark the {@code Task} of the specified {@code Person} using the specified index.
+     * Creates a UnmarkCommand to unmark the {@code Task} of the specified {@code Person} using the specified index.
      */
-    public MarkCommand(StudentId studentId, Index index) {
+    public UnmarkCommand(StudentId studentId, Index index) {
         requireNonNull(studentId);
         requireNonNull(index);
 
@@ -46,10 +44,10 @@ public class MarkCommand extends Command {
 
         try {
             requireNonNull(model);
-            model.markTaskOfPerson(studentId, index);
+            model.unmarkTaskOfPerson(studentId, index);
         } catch (InvalidTaskIndexException invalidTaskIndexException) {
             throw new InvalidTaskIndexException();
-        } catch (TaskAlreadyCompleteException taskAlreadyCompleteException) {
+        } catch (TaskAlreadyNotCompleteException taskAlreadyCompleteException) {
             throw new TaskAlreadyCompleteException();
         } catch (PersonNotFoundException personNotFoundException) {
             throw new PersonNotFoundException();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ManualCommand;
+import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case AssignCommand.COMMAND_WORD:
             return new AssignCommandParser().parse(arguments);
+
+        case MarkCommand.COMMAND_WORD:
+            return new MarkCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ManualCommand;
 import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -83,6 +84,9 @@ public class AddressBookParser {
 
         case MarkCommand.COMMAND_WORD:
             return new MarkCommandParser().parse(arguments);
+
+        case UnmarkCommand.COMMAND_WORD:
+            return new UnmarkCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,4 +15,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/"); // @Brandon: Delete this field
     public static final Prefix PREFIX_TAG = new Prefix("t/"); // @Brandon: Delete this field
     public static final Prefix PREFIX_TASK_NAME = new Prefix("tn/");
+    public static final Prefix PREFIX_INDEX = new Prefix("idx/");
 }

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.StudentId;
+
+/**
+ * Parses input arguments and creates a new MarkCommand object
+ */
+
+public class MarkCommandParser implements Parser<MarkCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkCommand and returns a MarkCommand
+     * object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MarkCommand parse(String args) throws ParseException {
+        MarkCommand markCommand;
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_ID) // supplied neither index nor id
+                && !arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "No ID, no Index"));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_ID) // supplied no index
+                && !arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "No Index"));
+        } else if (!arePrefixesPresent(argMultimap, PREFIX_ID) // supplied no id
+                && arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, "No ID"));
+        } else {
+            try {
+                System.out.println(argMultimap.getValue(PREFIX_ID));
+                StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_ID).get());
+                Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+                markCommand = new MarkCommand(studentId, index);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+            }
+        }
+        return markCommand;
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
@@ -7,48 +7,47 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.StudentId;
 
 /**
- * Parses input arguments and creates a new MarkCommand object
+ * Parses input arguments and creates a new UnmarkCommand object
  */
-
-public class MarkCommandParser implements Parser<MarkCommand> {
+public class UnmarkCommandParser implements Parser<UnmarkCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the MarkCommand and returns a MarkCommand
+     * Parses the given {@code String} of arguments in the context of the UnmarkCommand and returns a UnmarkCommand
      * object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public MarkCommand parse(String args) throws ParseException {
-        MarkCommand markCommand;
+    public UnmarkCommand parse(String args) throws ParseException {
+        UnmarkCommand unmarkCommand;
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_INDEX);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_ID) // supplied neither index nor id
                 && !arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
         } else if (arePrefixesPresent(argMultimap, PREFIX_ID) // supplied no index
                 && !arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
         } else if (!arePrefixesPresent(argMultimap, PREFIX_ID) // supplied no id
                 && arePrefixesPresent(argMultimap, PREFIX_INDEX)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
         } else {
             try {
                 System.out.println(argMultimap.getValue(PREFIX_ID));
                 StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_ID).get());
                 Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
-                markCommand = new MarkCommand(studentId, index);
+                unmarkCommand = new UnmarkCommand(studentId, index);
             } catch (ParseException pe) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE), pe);
             }
         }
-        return markCommand;
+        return unmarkCommand;
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -113,13 +113,26 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Marks task with {@code index} belonging to {@code Person} with {@code studentId} as done.
      *
      * @param studentId the student id of the person who's task is to be marked.
-     * @param index the task to be marked.
+     * @param index the task to be marked as done.
      */
     public void markTaskOfPerson(StudentId studentId, Index index) {
         requireNonNull(studentId);
         requireNonNull(index);
 
         persons.markTaskOfPerson(studentId, index);
+    }
+
+    /**
+     * Marks task with {@code index} belonging to {@code Person} with {@code studentId} as undone.
+     *
+     * @param studentId the student id of the person who's task is to be marked.
+     * @param index the task to be marked as undone.
+     */
+    public void unmarkTaskOfPerson(StudentId studentId, Index index) {
+        requireNonNull(studentId);
+        requireNonNull(index);
+
+        persons.unmarkTaskOfPerson(studentId, index);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.person.Task;
@@ -106,6 +107,19 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(task);
 
         persons.assignTaskToPerson(studentId, task);
+    }
+
+    /**
+     * Marks task with {@code index} belonging to {@code Person} with {@code studentId} as done.
+     *
+     * @param studentId the student id of the person who's task is to be marked.
+     * @param index the task to be marked.
+     */
+    public void markTaskOfPerson(StudentId studentId, Index index) {
+        requireNonNull(studentId);
+        requireNonNull(index);
+
+        persons.markTaskOfPerson(studentId, index);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.person.Task;
@@ -84,6 +85,13 @@ public interface Model {
      * The {@code task} should be unique and not a duplicate of already assigned task.
      */
     void assignTaskToPerson(StudentId studentId, Task task);
+
+    /**
+     * Marks {@code Task} to {@code person} with {@code studentId}.
+     * A person with {@code studentId} must exist in the address book.
+     * The {@code task} should be an existing unmarked assigned task.
+     */
+    void markTaskOfPerson(StudentId studentId, Index index);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -92,6 +92,12 @@ public interface Model {
      * The {@code task} should be an existing unmarked assigned task.
      */
     void markTaskOfPerson(StudentId studentId, Index index);
+    /**
+     * Unmarks {@code Task} to {@code person} with {@code studentId}.
+     * A person with {@code studentId} must exist in the address book.
+     * The {@code task} should be an existing marked assigned task.
+     */
+    void unmarkTaskOfPerson(StudentId studentId, Index index);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.person.Task;
@@ -117,6 +118,13 @@ public class ModelManager implements Model {
     public void assignTaskToPerson(StudentId studentId, Task task) {
         requireAllNonNull(studentId, task);
         addressBook.assignTaskToPerson(studentId, task);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public void markTaskOfPerson(StudentId studentId, Index index) {
+        requireAllNonNull(studentId, index);
+        addressBook.markTaskOfPerson(studentId, index);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -128,6 +128,13 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    @Override
+    public void unmarkTaskOfPerson(StudentId studentId, Index index) {
+        requireAllNonNull(studentId, index);
+        addressBook.unmarkTaskOfPerson(studentId, index);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/person/Task.java
+++ b/src/main/java/seedu/address/model/person/Task.java
@@ -124,7 +124,11 @@ public class Task {
 
     @Override
     public String toString() {
-        return taskName;
+        if (isComplete) {
+            return "[X] " + taskName;
+        } else {
+            return "[ ] " + taskName;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -9,9 +9,13 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.DuplicateTaskException;
+import seedu.address.model.person.exceptions.InvalidTaskIndexException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
+
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -118,6 +122,41 @@ public class UniquePersonList implements Iterable<Person> {
                     setPerson(currPerson, updatedPerson);
                 } else {
                     throw new DuplicateTaskException();
+                }
+            }
+        }
+
+        if (!isPersonFound) {
+            throw new PersonNotFoundException();
+        }
+    }
+
+    /**
+     * Mark {@code task} task belonging to a person {@code studentId} as done.
+     *
+     * @param studentId the student id of the person's whose task is to be marked.
+     * @param index the index of he task to be marked as complete.
+     */
+
+    public void markTaskOfPerson(StudentId studentId, Index index) {
+        requireAllNonNull(studentId, index);
+        boolean isPersonFound = false;
+
+        for (Person currPerson: internalList) {
+            if (currPerson.getStudentId().equals(studentId)) {
+                isPersonFound = true;
+                Person updatedPerson = currPerson.getCopy();
+                TaskList updatedPersonTaskList = updatedPerson.getTaskList();
+                int numberOfTasks = updatedPersonTaskList.getNumberOfTasks();
+                if (!updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
+                    if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                        updatedPersonTaskList.markTaskAsComplete(index.getZeroBased());
+                        setPerson(currPerson, updatedPerson);
+                    } else {
+                        throw new InvalidTaskIndexException();
+                    }
+                } else {
+                    throw new TaskAlreadyCompleteException();
                 }
             }
         }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.exceptions.DuplicateTaskException;
 import seedu.address.model.person.exceptions.InvalidTaskIndexException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
+import seedu.address.model.person.exceptions.TaskAlreadyNotCompleteException;
 
 
 /**
@@ -134,7 +135,7 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Mark {@code task} task belonging to a person {@code studentId} as done.
      *
-     * @param studentId the student id of the person's whose task is to be marked.
+     * @param studentId the student id of the person's whose task is to be marked as done.
      * @param index the index of he task to be marked as complete.
      */
 
@@ -157,6 +158,40 @@ public class UniquePersonList implements Iterable<Person> {
                     }
                 } else {
                     throw new TaskAlreadyCompleteException();
+                }
+            }
+        }
+
+        if (!isPersonFound) {
+            throw new PersonNotFoundException();
+        }
+    }
+
+    /**
+     * Mark {@code task} task belonging to a person {@code studentId} as undone.
+     *
+     * @param studentId the student id of the person's whose task is to be marked as undone.
+     * @param index the index of he task to be marked as incomplete.
+     */
+    public void unmarkTaskOfPerson(StudentId studentId, Index index) {
+        requireAllNonNull(studentId, index);
+        boolean isPersonFound = false;
+
+        for (Person currPerson: internalList) {
+            if (currPerson.getStudentId().equals(studentId)) {
+                isPersonFound = true;
+                Person updatedPerson = currPerson.getCopy();
+                TaskList updatedPersonTaskList = updatedPerson.getTaskList();
+                int numberOfTasks = updatedPersonTaskList.getNumberOfTasks();
+                if (updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
+                    if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                        updatedPersonTaskList.markTaskAsNotComplete(index.getZeroBased());
+                        setPerson(currPerson, updatedPerson);
+                    } else {
+                        throw new InvalidTaskIndexException();
+                    }
+                } else {
+                    throw new TaskAlreadyNotCompleteException();
                 }
             }
         }

--- a/src/main/java/seedu/address/model/person/exceptions/InvalidTaskIndexException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/InvalidTaskIndexException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in Invalid task Index (Task index are considered as invalid if it is less
+ * than 1 or larger than the number of tasks).
+ */
+
+public class InvalidTaskIndexException extends RuntimeException {
+    public InvalidTaskIndexException() {
+        super("Invalid Task Index Input!");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/PersonNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/PersonNotFoundException.java
@@ -3,4 +3,8 @@ package seedu.address.model.person.exceptions;
 /**
  * Signals that the operation is unable to find the specified person.
  */
-public class PersonNotFoundException extends RuntimeException {}
+public class PersonNotFoundException extends RuntimeException {
+    public PersonNotFoundException() {
+        super("There is no such person!");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/TaskAlreadyCompleteException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/TaskAlreadyCompleteException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in marking a task that is already completed (Task index are considered as
+ * completed if it is already marked as done.).
+ */
+
+public class TaskAlreadyCompleteException extends RuntimeException {
+    public TaskAlreadyCompleteException() {
+        super("Task is already complete!");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/TaskAlreadyNotCompleteException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/TaskAlreadyNotCompleteException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in marking a task that is already not completed (Task index are considered as
+ * not completed if it is not marked as done.).
+ */
+public class TaskAlreadyNotCompleteException extends RuntimeException {
+    public TaskAlreadyNotCompleteException() {
+        super("Task is already unmarked!");
+    }
+}

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -2,7 +2,7 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;    
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -2,7 +2,7 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
+import javafx.scene.layout.HBox;    
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Person;


### PR DESCRIPTION
Implemented `mark` and `unmark` command.

Updated UserGuide.md to included prefixes for mark and unmark commands to the following format:
`mark i/STUDENT_ID idx/UNMARKED_TASK_INDEX` 
`unmark i/STUDENT_ID idx/UNMARKED_TASK_INDEX`

Example:
`mark i/A0123456X idx/1`
`unmark i/A0123456X idx/2`

**Notes:**
Have yet to implement testcases.