### PR TITLE
Change the display text of the task command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -83,13 +83,14 @@ public class TaskCommand extends Command {
 
         if (incompleteTasks.isEmpty()) { // This means that all tasks are completed.
             return new CommandResult(String.format(MESSAGE_SUCCESS, studentId,
-                    "Completed tasks:\n" + completedTasks));
+                    "Completed tasks:\n" + completedTasks.display()));
         } else if (completedTasks.isEmpty()) { // This means that all tasks are incomplete.
             return new CommandResult(String.format(MESSAGE_SUCCESS, studentId,
-                    "Incomplete tasks:\n" + incompleteTasks));
+                    "Incomplete tasks:\n" + incompleteTasks.display()));
         } else { // Mixture of different types of tasks.
             return new CommandResult(String.format(MESSAGE_SUCCESS, studentId,
-                    "Incomplete tasks:\n" + incompleteTasks + "\n" + "Completed tasks:\n" + completedTasks));
+                    "Incomplete tasks:\n" + incompleteTasks.display() + "\n"
+                            + "Completed tasks:\n" + completedTasks.display()));
         }
     }
 

--- a/src/main/java/seedu/address/model/person/TaskList.java
+++ b/src/main/java/seedu/address/model/person/TaskList.java
@@ -98,6 +98,25 @@ public class TaskList {
         return taskList.isEmpty();
     }
 
+    /**
+     * Displays all the tasks in the list (without the completion status)
+     *
+     * @return a string that represents the current TaskList.
+     */
+    public String display() {
+        String taskStr = "";
+
+        int idxNum = 1;
+        String separate = ". ";
+
+        for (Task task: taskList) {
+            taskStr += idxNum + separate + task.getTaskName() + "\n";
+            idxNum++;
+        }
+
+        return taskStr;
+    }
+
     @Override
     public String toString() {
         String taskStr = "";


### PR DESCRIPTION
Since the Task model's toString() method has been modified to include the checkboxes, it has changed the display text in the Task command to the following:
![image_2022-03-15_19-01-29](https://user-images.githubusercontent.com/65613207/158365946-af3f69bc-7abb-40df-8e4b-9038b47404c6.png)
 
As we are already separating the tasks into 2 distinct sections (completed and incomplete), I decided to add a new display() method in TaskList that is similar to the toString(), but uses the task name only.

This is the current output after the change:
![image](https://user-images.githubusercontent.com/65613207/158366241-2d1f493c-deca-4377-abf9-60b0924c747d.png)
