### PR TITLE
Fix bugs for mark and unmark command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -26,6 +26,9 @@ public class MarkCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z " + PREFIX_INDEX + "1";
 
     public static final String MARKED_TASK_SUCCESS = "Task for %1$s marked";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "There is no person with the given studentId";
+    public static final String TASK_ALREADY_DONE = "Task is already marked as done";
+    public static final String INVALID_TASK_INDEX = "Invalid index";
 
     private final StudentId studentId;
     private final Index index;
@@ -48,11 +51,11 @@ public class MarkCommand extends Command {
             requireNonNull(model);
             model.markTaskOfPerson(studentId, index);
         } catch (InvalidTaskIndexException invalidTaskIndexException) {
-            throw new InvalidTaskIndexException();
+            throw new CommandException(INVALID_TASK_INDEX);
         } catch (TaskAlreadyCompleteException taskAlreadyCompleteException) {
-            throw new TaskAlreadyCompleteException();
+            throw new CommandException(TASK_ALREADY_DONE);
         } catch (PersonNotFoundException personNotFoundException) {
-            throw new PersonNotFoundException();
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
         } finally {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -11,7 +11,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.person.exceptions.InvalidTaskIndexException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
-import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
 import seedu.address.model.person.exceptions.TaskAlreadyNotCompleteException;
 
 public class UnmarkCommand extends Command {
@@ -24,6 +23,9 @@ public class UnmarkCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z " + PREFIX_INDEX + "1";
 
     public static final String MARKED_TASK_SUCCESS = "Task for %1$s unmarked";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "There is no person with the given studentId";
+    public static final String TASK_ALREADY_NOT_DONE = "Task is already marked as undone";
+    public static final String INVALID_TASK_INDEX = "Invalid index";
 
     private final StudentId studentId;
     private final Index index;
@@ -46,11 +48,11 @@ public class UnmarkCommand extends Command {
             requireNonNull(model);
             model.unmarkTaskOfPerson(studentId, index);
         } catch (InvalidTaskIndexException invalidTaskIndexException) {
-            throw new InvalidTaskIndexException();
-        } catch (TaskAlreadyNotCompleteException taskAlreadyCompleteException) {
-            throw new TaskAlreadyCompleteException();
+            throw new CommandException(INVALID_TASK_INDEX);
+        } catch (TaskAlreadyNotCompleteException taskAlreadyNotCompleteException) {
+            throw new CommandException(TASK_ALREADY_NOT_DONE);
         } catch (PersonNotFoundException personNotFoundException) {
-            throw new PersonNotFoundException();
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
         } finally {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -17,7 +17,6 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.person.exceptions.TaskAlreadyCompleteException;
 import seedu.address.model.person.exceptions.TaskAlreadyNotCompleteException;
 
-
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
  * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
@@ -149,15 +148,15 @@ public class UniquePersonList implements Iterable<Person> {
                 Person updatedPerson = currPerson.getCopy();
                 TaskList updatedPersonTaskList = updatedPerson.getTaskList();
                 int numberOfTasks = updatedPersonTaskList.getNumberOfTasks();
-                if (!updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
-                    if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                    if (!updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
                         updatedPersonTaskList.markTaskAsComplete(index.getZeroBased());
                         setPerson(currPerson, updatedPerson);
                     } else {
-                        throw new InvalidTaskIndexException();
+                        throw new TaskAlreadyCompleteException();
                     }
                 } else {
-                    throw new TaskAlreadyCompleteException();
+                    throw new InvalidTaskIndexException();
                 }
             }
         }
@@ -183,15 +182,15 @@ public class UniquePersonList implements Iterable<Person> {
                 Person updatedPerson = currPerson.getCopy();
                 TaskList updatedPersonTaskList = updatedPerson.getTaskList();
                 int numberOfTasks = updatedPersonTaskList.getNumberOfTasks();
-                if (updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
-                    if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                if (index.getZeroBased() < numberOfTasks && index.getOneBased() > 0) {
+                    if (updatedPersonTaskList.getTaskList().get(index.getZeroBased()).isTaskComplete()) {
                         updatedPersonTaskList.markTaskAsNotComplete(index.getZeroBased());
                         setPerson(currPerson, updatedPerson);
                     } else {
-                        throw new InvalidTaskIndexException();
+                        throw new TaskAlreadyNotCompleteException();
                     }
                 } else {
-                    throw new TaskAlreadyNotCompleteException();
+                    throw new InvalidTaskIndexException();
                 }
             }
         }


### PR DESCRIPTION
Mark and unmark were not catching exceptions when an invalid index and when the tasks were already marked/unmarked respectively

The previous logic was to check if tasks were marked/unmarked first before checking if the index was even valid. The sequence was swapped to check if the index was valid first, then checking if the tasks were marked/unmarked.

Updated the logic and ensured CommandExceptions were thrown instead.