### PR TITLE
Implement filter function for module code

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -100,15 +100,17 @@ Example:
 
 Allows the user to look up the details of a particular student.
 
-Format: `find n/STUDENT_NAME` (or) `find i/STUDENT_ID`
+Format: `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` (or) `find m/MODULE_CODE`
 
-* The student whose name or student id is specified after the `find` command will appear in the resulting list.
+* The student whose name, student id or module code is specified after the `find` command will appear in the resulting list.
 
 Example:
 * `find n/John`
     * Displays the particulars of the students whose names include John.
 * `find i/AXXXXXXXR`
     * Displays the particulars of the student with student ID AXXXXXXXR.
+* `find m/CS2103T`
+    * Displays the particulars of the student with module code CS2103T. Also works for module codes with varying lengths.
 
 ### Checking all the tasks that a student has: `task`
 
@@ -255,7 +257,7 @@ Action      | Format, Examples
 ------------|------------------
 **Add**     | `add i/MATRICULATION_NO n/STUDENT_NAME m/MODULE_CODE [p/PHONE_NUMBER] [h/TELEGRAM_HANDLE] [e/EMAIL_ADDRESS] ` <br> e.g., `add i/AXXXXXXXR n/john m/CS2103T p/98765432 t/johnnn e/e0123456@u.nus.edu`
 **Delete**  | `delete STUDENT_INDEX` (or) `delete i/STUDENT_ID` <br> e.g., `delete 10`, `delete i/AXXXXXXXR`
-**Find**    | `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` <br> e.g., `find n/john`, `find i/AXXXXXXXR`
+**Find**    | `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` (or) `find i/MODULE_CODE` <br> e.g., `find n/john`, `find i/AXXXXXXXR`, `find i/CS2103T`
 **Manual**  | `manual COMMAND_NAME` <br> e.g., `manual add`
 **Exit**    | `exit`
 **Task**    | `task i/STUDENT_ID` <br> e.g., `task i/AXXXXXXXR`

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -10,7 +10,8 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.StudentIdContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose name, student id or module code
+ * contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,11 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.ModuleCodeContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.StudentIdContainsKeywordsPredicate;
 
@@ -18,13 +18,16 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain "
-            + "the specified search term or matriculation number and displays them as a list with index numbers.\n"
-            + "Parameters: " + PREFIX_NAME + "STUDENT_NAME " + "or " + PREFIX_ID + "STUDENT_ID \n"
+            + "the specified search term, matriculation number or module code "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: " + PREFIX_NAME + "STUDENT_NAME " + "or " + PREFIX_ID + "STUDENT_ID " + "or "
+            + PREFIX_MODULE_CODE + "MODULE_CODE\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "John " + "or " + COMMAND_WORD + " "
-            + PREFIX_ID + "A0123456Z \n";
+            + PREFIX_ID + "A0123456Z " + "or " + COMMAND_WORD + " "+ PREFIX_NAME + "CS2103T\n";
 
     private final NameContainsKeywordsPredicate namePredicate;
     private final StudentIdContainsKeywordsPredicate idPredicate;
+    private final ModuleCodeContainsKeywordsPredicate modCodePredicate;
 
     /**
      * Creates a FindCommand to find the specified {@code Person} using the person's name.
@@ -32,6 +35,7 @@ public class FindCommand extends Command {
     public FindCommand(NameContainsKeywordsPredicate predicate) {
         this.namePredicate = predicate;
         this.idPredicate = null;
+        this.modCodePredicate = null;
     }
 
     /**
@@ -40,6 +44,16 @@ public class FindCommand extends Command {
     public FindCommand(StudentIdContainsKeywordsPredicate predicate) {
         this.idPredicate = predicate;
         this.namePredicate = null;
+        this.modCodePredicate = null;
+    }
+
+    /**
+     * Creates a FindCommand to find the specified {@code Person} using the person's module code.
+     */
+    public FindCommand(ModuleCodeContainsKeywordsPredicate predicate) {
+        this.modCodePredicate = predicate;
+        this.namePredicate = null;
+        this.idPredicate = null;
     }
 
     @Override
@@ -47,8 +61,10 @@ public class FindCommand extends Command {
         requireNonNull(model);
         if (namePredicate != null) { // student name was used for the command
             model.updateFilteredPersonList(namePredicate);
-        } else { // student id was used for the command
+        } else if (idPredicate != null){ // student id was used for the command
             model.updateFilteredPersonList(idPredicate);
+        } else { // module code was used for the command
+            model.updateFilteredPersonList(modCodePredicate);
         }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
@@ -64,10 +80,17 @@ public class FindCommand extends Command {
                 return false;
             }
             FindCommand commandToCompare = (FindCommand) other;
-            if (this.namePredicate == null && this.idPredicate != null) { // only idPredicate present
+            // only idPredicate present
+            if (this.namePredicate == null && this.idPredicate != null && this.modCodePredicate == null) {
                 return idPredicate.equals(commandToCompare.idPredicate); // state check
-            } else if (this.idPredicate == null && this.namePredicate != null) { // only namePredicate present
+            }
+            // only namePredicate present
+            else if (this.idPredicate == null && this.namePredicate != null && this.modCodePredicate == null) {
                 return namePredicate.equals(commandToCompare.namePredicate); // state check
+            }
+            // only modCodePredicate present
+            else if (this.idPredicate == null && this.namePredicate == null && this.modCodePredicate != null) {
+                return modCodePredicate.equals(commandToCompare.modCodePredicate); // state check
             } else {
                 return false;
             }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE_CODE;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -13,6 +14,8 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.StudentId;
 import seedu.address.model.person.StudentIdContainsKeywordsPredicate;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleCodeContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -29,9 +32,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         FindCommand findCommand;
 
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID);
-
-        if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID) // user inputted both name and id
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_ID, PREFIX_MODULE_CODE);
+        // user inputted name, id, modcode or any two combinations of the two
+        if (arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID, PREFIX_MODULE_CODE)
+                || arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ID)
+                || arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_MODULE_CODE)
+                || arePrefixesPresent(argMultimap, PREFIX_ID, PREFIX_MODULE_CODE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -44,6 +50,10 @@ public class FindCommandParser implements Parser<FindCommand> {
             StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_ID).get());
             String[] idKeywords = studentId.toString().split("\\s+");
             findCommand = new FindCommand(new StudentIdContainsKeywordsPredicate(Arrays.asList(idKeywords)));
+        } else if (arePrefixesPresent(argMultimap, PREFIX_MODULE_CODE)) { // module code was used
+            ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MODULE_CODE).get());
+            String[] modCodeKeywords = moduleCode.toString().split("\\s+");
+            findCommand = new FindCommand(new ModuleCodeContainsKeywordsPredicate(Arrays.asList(modCodeKeywords)));
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/person/ModuleCode.java
+++ b/src/main/java/seedu/address/model/person/ModuleCode.java
@@ -8,8 +8,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}
  */
 public class ModuleCode {
-    public static final String MESSAGE_CONSTRAINTS = "Module code should only contain alphanumeric characters";
-    public static final String VALIDATION_REGEX = "[a-zA-Z0-9]*";
+    public static final String MESSAGE_CONSTRAINTS = "Module code should only contain alphanumeric "
+            + "characters and should not be blank";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+$";
 
     public final String moduleCode;
 

--- a/src/main/java/seedu/address/model/person/ModuleCodeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ModuleCodeContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Module Code} matches any of the keywords given.
+ */
+public class ModuleCodeContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public ModuleCodeContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getModuleCode().moduleCode, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ModuleCodeContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ModuleCodeContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}


### PR DESCRIPTION
Implements the filter function for module code. Closes #94.

As there is overlap between filter and find, I've decided to subsume this under the find command.

Usage: find m/MODULE_CODE

Validation regex for Module Code was updated to prevent blank inputs (in addition to being alphanumeric only).

User guide was updated to reflect the new possible input.

TODO: Testcases, DG