### PR TITLE
Fix testcases

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -165,12 +165,49 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
+
+        boolean isPhoneEqual;
+
+        if (otherPerson.getPhone() == null && getPhone() == null) {
+            isPhoneEqual = true;
+        } else if (otherPerson.getPhone() == null) {
+            isPhoneEqual = false;
+        } else if (getPhone() == null) {
+            isPhoneEqual = false;
+        } else {
+            isPhoneEqual = otherPerson.getPhone().equals(getPhone());
+        }
+
+        boolean isTelegramHandleEqual;
+
+        if (otherPerson.getTelegramHandle() == null && getTelegramHandle() == null) {
+            isTelegramHandleEqual = true;
+        } else if (otherPerson.getTelegramHandle() == null) {
+            isTelegramHandleEqual = false;
+        } else if (getTelegramHandle() == null) {
+            isTelegramHandleEqual = false;
+        } else {
+            isTelegramHandleEqual = otherPerson.getTelegramHandle().equals(getTelegramHandle());
+        }
+
+        boolean isEmailEqual;
+
+        if (otherPerson.getEmail() == null && getEmail() == null) {
+            isEmailEqual = true;
+        } else if (otherPerson.getEmail() == null) {
+            isEmailEqual = false;
+        } else if (getEmail() == null) {
+            isEmailEqual = false;
+        } else {
+            isEmailEqual = otherPerson.getEmail().equals(getEmail());
+        }
+
         return otherPerson.getStudentId().equals(getStudentId())
                 && otherPerson.getName().equals(getName())
                 && otherPerson.getModuleCode().equals(getModuleCode())
-                && otherPerson.getPhone().equals(getPhone())
-                && otherPerson.getTelegramHandle().equals(getTelegramHandle())
-                && otherPerson.getEmail().equals(getEmail())
+                && isPhoneEqual
+                && isTelegramHandleEqual
+                && isEmailEqual
                 && otherPerson.getTaskList().equals(getTaskList());
     }
 
@@ -190,24 +227,20 @@ public class Person {
                 .append(getModuleCode());
 
         Phone currentPhone = getPhone();
-        if (currentPhone != null) {
-            builder.append("; Phone Number: ").append(currentPhone);
-        }
+        builder.append("; Phone Number: ").append(currentPhone);
+
 
         TelegramHandle currentTelegramHandle = getTelegramHandle();
-        if (currentTelegramHandle != null) {
-            builder.append("; Telegram Handle: @").append(currentTelegramHandle);
-        }
+        builder.append("; Telegram Handle: @").append(currentTelegramHandle);
+
 
         Email currentEmail = getEmail();
-        if (currentEmail != null) {
-            builder.append("; Email: ").append(currentEmail);
-        }
+        builder.append("; Email: ").append(currentEmail);
+
 
         TaskList currentTaskList = getTaskList();
-        if (currentTaskList != null) {
-            builder.append("; Tasks: ").append(currentTaskList);
-        }
+        builder.append("; Tasks: ").append(currentTaskList);
+
 
         return builder.toString();
     }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -9,7 +9,7 @@
     "email" : "aliceee@u.nus.edu",
     "taskList" : {
       "taskList" : [ {
-        "taskName" : "task a",
+        "taskName" : "Task A",
         "isComplete" : false
       } ]
     }
@@ -22,7 +22,7 @@
     "email" : "bensonnn@u.nus.edu",
     "taskList" : {
       "taskList" : [ {
-        "taskName" : "task b",
+        "taskName" : "Task B",
         "isComplete" : true
       } ]
     }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -25,12 +26,12 @@ public class ClearCommandTest {
     @Test
     public void execute_nonEmptyAddressBook_success() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-        CommandResult result = new ClearCommand().execute(model);
         CommandResult expectedCommandResult =
-                new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
+            new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
 
-        assertEquals(expectedCommandResult, result);
+        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult,
+          expectedModel);
     }
-
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,25 +1,37 @@
 package seedu.address.logic.commands;
 
-public class ClearCommandTest {
-    // TODO: Fix this testcase
-    //    @Test
-    //    public void execute_emptyAddressBook_success() {
-    //        Model model = new ModelManager();
-    //        Model expectedModel = new ModelManager();
-    //
-    //        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION,
-    //          expectedModel);
-    //    }
+import org.junit.jupiter.api.Test;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
-    // TODO: Fix this testcase
-    //    @Test
-    //    public void execute_nonEmptyAddressBook_success() {
-    //        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    //        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    //        expectedModel.setAddressBook(new AddressBook());
-    //
-    //        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION,
-    //          expectedModel);
-    //    }
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+public class ClearCommandTest {
+    @Test
+    public void execute_emptyAddressBook_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        CommandResult expectedCommandResult
+                = new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
+
+        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult,
+          expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyAddressBook_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        CommandResult result = new ClearCommand().execute(model);
+        CommandResult expectedCommandResult
+                = new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
+
+        assertEquals(expectedCommandResult, result);
+    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -31,7 +29,6 @@ public class ClearCommandTest {
         CommandResult expectedCommandResult =
             new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
 
-        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult,
-          expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class ClearCommandTest {
     @Test
@@ -16,11 +16,10 @@ public class ClearCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        CommandResult expectedCommandResult
-                = new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
+        CommandResult expectedCommandResult =
+                new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
 
-        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult,
-          expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, expectedCommandResult, expectedModel);
     }
 
     @Test
@@ -28,8 +27,8 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
         CommandResult result = new ClearCommand().execute(model);
-        CommandResult expectedCommandResult
-                = new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
+        CommandResult expectedCommandResult =
+                new CommandResult(ClearCommand.MESSAGE_REQUEST_USER_CONFIRMATION, true);
 
         assertEquals(expectedCommandResult, result);
     }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -21,11 +21,17 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TELEGRAM_HANDLE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TELEGRAM_HANDLE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_HANDLE_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
@@ -76,24 +82,24 @@ public class AddCommandParserTest {
                 + TELEGRAM_HANDLE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB, new AddCommand(expectedPerson));
 
     }
-    // TODO: Fix this testcase
-    //    @Test
-    //    public void parse_optionalFieldsMissing_success() {
-    //        // missing phone
-    //        Person expectedPerson = new PersonBuilder().withStudentId(VALID_ID_AMY).withName(VALID_NAME_AMY)
-    //                .withModuleCode(VALID_MODULE_CODE_AMY).withPhone(null)
-    //                .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY).withEmail(VALID_EMAIL_AMY).build();
-    //        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY
-    //                + TELEGRAM_HANDLE_DESC_AMY + EMAIL_DESC_AMY, new AddCommand(expectedPerson));
-    //
-    //        // missing telegramHandle
-    //        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY + PHONE_DESC_AMY
-    //                + EMAIL_DESC_AMY, new AddCommand(expectedPerson));
-    //
-    //        // missing email
-    //        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY + PHONE_DESC_AMY
-    //                + TELEGRAM_HANDLE_DESC_AMY, new AddCommand(expectedPerson));
-    //    }
+     //TODO: Fix this testcase
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // missing phone
+        Person expectedPerson = new PersonBuilder(AMY).withPhone(null).build();
+        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY
+                + TELEGRAM_HANDLE_DESC_AMY + EMAIL_DESC_AMY, new AddCommand(expectedPerson));
+
+        // missing telegramHandle
+        expectedPerson = new PersonBuilder(AMY).withTelegramHandle(null).build();
+        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY + PHONE_DESC_AMY
+                + EMAIL_DESC_AMY, new AddCommand(expectedPerson));
+
+        // missing email
+        expectedPerson = new PersonBuilder(AMY).withEmail(null).build();
+        assertParseSuccess(parser, ID_DESC_AMY + NAME_DESC_AMY + MODULE_CODE_DESC_AMY + PHONE_DESC_AMY
+                + TELEGRAM_HANDLE_DESC_AMY, new AddCommand(expectedPerson));
+    }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -21,14 +21,9 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TELEGRAM_HANDLE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TELEGRAM_HANDLE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_HANDLE_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -82,7 +77,7 @@ public class AddCommandParserTest {
                 + TELEGRAM_HANDLE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB, new AddCommand(expectedPerson));
 
     }
-     //TODO: Fix this testcase
+
     @Test
     public void parse_optionalFieldsMissing_success() {
         // missing phone

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -16,36 +16,30 @@ import org.junit.jupiter.api.Test;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
-    // TODO: Fix this testcase
-    //    @Test
-    //    public void isSamePerson() {
-    //        // same object -> returns true
-    //        assertTrue(ALICE.isSamePerson(ALICE));
-    //
-    //        // null -> returns false
-    //        assertFalse(ALICE.isSamePerson(null));
-    //
-    //        // same id, all other attributes different -> returns true
-    //        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB)
-    //                .withModuleCode(VALID_MODULE_CODE_BOB)
-    //                .withPhone(VALID_PHONE_BOB).withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB)
-    //                .withEmail(VALID_EMAIL_BOB)
-    //                .build();
-    //        assertTrue(ALICE.isSamePerson(editedAlice));
-    //
-    //        // different id, all other attributes same -> returns false
-    //        editedAlice = new PersonBuilder(ALICE).withStudentId(VALID_ID_BOB).build();
-    //        assertFalse(ALICE.isSamePerson(editedAlice));
-    //
-    //        // id differs in case, all other attributes same -> returns false
-    //        Person editedBob = new PersonBuilder(BOB).withStudentId(VALID_ID_BOB.toLowerCase()).build();
-    //        assertFalse(BOB.isSamePerson(editedBob));
-    //
-    //        // id has trailing spaces, all other attributes same -> returns false
-    //        String idWithTrailingSpaces = VALID_ID_BOB + " ";
-    //        editedBob = new PersonBuilder(BOB).withStudentId(idWithTrailingSpaces).build();
-    //        assertFalse(BOB.isSamePerson(editedBob));
-    //    }
+    @Test
+    public void isSamePerson() {
+        // same object -> returns true
+        assertTrue(ALICE.isSamePerson(ALICE));
+
+        // null -> returns false
+        assertFalse(ALICE.isSamePerson(null));
+
+        // same id, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB)
+                .withModuleCode(VALID_MODULE_CODE_BOB)
+                .withPhone(VALID_PHONE_BOB).withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .build();
+        assertTrue(ALICE.isSamePerson(editedAlice));
+
+        // different id, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withStudentId(VALID_ID_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // id differs in case, all other attributes same -> returns false
+        Person editedBob = new PersonBuilder(BOB).withStudentId(VALID_ID_BOB.toLowerCase()).build();
+        assertFalse(BOB.isSamePerson(editedBob));
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -1,5 +1,6 @@
 package seedu.address.storage;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
+import seedu.address.model.AddressBook;
+import seedu.address.testutil.TypicalPersons;
 
 public class JsonSerializableAddressBookTest {
 
@@ -18,15 +21,14 @@ public class JsonSerializableAddressBookTest {
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
 
-    // TODO: Fix this testcase
-    //    @Test
-    //    public void toModelType_typicalPersonsFile_success() throws Exception {
-    //        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
-    //                JsonSerializableAddressBook.class).get();
-    //        AddressBook addressBookFromFile = dataFromFile.toModelType();
-    //        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
-    //        assertEquals(addressBookFromFile, typicalPersonsAddressBook);
-    //    }
+    @Test
+    public void toModelType_typicalPersonsFile_success() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        assertEquals(addressBookFromFile, typicalPersonsAddressBook);
+    }
 
     @Test
     public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -84,7 +84,11 @@ public class PersonBuilder {
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
-        this.phone = new Phone(phone);
+        if (phone == null) {
+            this.phone = null;
+        } else {
+            this.phone = new Phone(phone);
+        }
         return this;
     }
 
@@ -92,7 +96,11 @@ public class PersonBuilder {
      * Sets the {@code TelegramHandle} of the {@code Person} that we are building.
      */
     public PersonBuilder withTelegramHandle(String telegramHandle) {
-        this.telegramHandle = new TelegramHandle(telegramHandle);
+        if (telegramHandle == null) {
+            this.telegramHandle = null;
+        } else {
+            this.telegramHandle = new TelegramHandle(telegramHandle);
+        }
         return this;
     }
 
@@ -100,7 +108,11 @@ public class PersonBuilder {
      * Sets the {@code Email} of the {@code Person} that we are building.
      */
     public PersonBuilder withEmail(String email) {
-        this.email = new Email(email);
+        if (email == null) {
+            this.email = null;
+        } else {
+            this.email = new Email(email);
+        }
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -30,10 +30,10 @@ public class TypicalPersons {
      */
     public static final Person ALICE = new PersonBuilder().withStudentId("A1000000Z").withName("Alice")
             .withModuleCode("CS2101").withPhone("10000000").withTelegramHandle("aliceee")
-            .withEmail("aliceee@u.nus.edu").withTaskList("task a", false).build();
+            .withEmail("aliceee@u.nus.edu").withTaskList("Task A", false).build();
     public static final Person BENSON = new PersonBuilder().withStudentId("A2000000Z").withName("Benson")
             .withModuleCode("CS2102").withPhone("20000000").withTelegramHandle("bensonnn")
-            .withEmail("bensonnn@u.nus.edu").withTaskList("task b", true).build();
+            .withEmail("bensonnn@u.nus.edu").withTaskList("Task B", true).build();
     public static final Person CARL = new PersonBuilder().withStudentId("A3000000Z").withName("Carl")
             .withModuleCode("CS2103").withPhone("30000000").withTelegramHandle("carlll")
             .withEmail("carlll@u.nus.edu").build();


### PR DESCRIPTION
1. Accidentally included tasks in the typicalPersonsAddressBook.json that are not in titlecase, which caused JsonSerializableAddressBookTest to fail in our current implementation
2. The testcase in PersonTest is no longer applicable since our current Regex for `StudentId` does not allow for any trailing whitespace.
3. Both testcases in ClearCommandTest have to be modified since we are currently using a two-stage process for `clear`.
**Note: Might want to implement similar testcases for ConfirmClearCommand.
4. I realised the optional field in Persons might result in a `NullPointerException` when comparing between 2 `Persons` using `equals()`. In addition, changes were made to some methods in `PersonBuilder`, such that we instantiate the optional field with null instead of passing a `String null` to the constructor. This fixes the `AddCommandParserTest`.