### PR TITLE
Implement multi delete by indices

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,14 +85,17 @@ Example:
 
 Deletes a student from TAPA.
 
-Format: `delete STUDENT_INDEX` (or) `delete i/STUDENT_ID`
+Format: `delete STUDENT_INDEX...` (or) `delete i/STUDENT_ID`
 
 * The student corresponding to the index or matriculation number (specified after the `delete` command) will be removed from TAPA.
 * An error message will be displayed to the user if the specified index is a negative number or larger than the number of students in TAPA, or there is no student with the specified matriculation number.
+* Multiple indices can be inputted in order to delete multiple students.
 
 Example:
 * `delete 10`
     * A student named John (whose list index is “10”) is deleted from TAPA.
+* `delete 10 20`
+    * The students named John and Mary (whose list indices are “10” and “20”) are deleted from TAPA.
 * `delete i/A0123456Z`
     * A student named John whose matriculation number is "A0123456Z" is deleted from TAPA.
 
@@ -273,7 +276,7 @@ Format: `exit`
 Action      | Format, Examples
 ------------|------------------
 **Add**     | `add i/MATRICULATION_NO n/STUDENT_NAME m/MODULE_CODE [p/PHONE_NUMBER] [h/TELEGRAM_HANDLE] [e/EMAIL_ADDRESS] ` <br> e.g., `add i/AXXXXXXXR n/john m/CS2103T p/98765432 t/johnnn e/e0123456@u.nus.edu`
-**Delete**  | `delete STUDENT_INDEX` (or) `delete i/STUDENT_ID` <br> e.g., `delete 10`, `delete i/AXXXXXXXR`
+**Delete**  | `delete STUDENT_INDEX...` (or) `delete i/STUDENT_ID` <br> e.g., `delete 10`, `delete 10 20`, `delete i/AXXXXXXXR`
 **Find**    | `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` <br> e.g., `find n/john`, `find i/AXXXXXXXR`
 **Manual**  | `manual [COMMAND_NAME]` <br> e.g., `manual add`, `manual`
 **Find**    | `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` (or) `find m/MODULE_CODE` <br> e.g., `find n/john`, `find i/AXXXXXXXR`, `find m/CS2103T`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -102,7 +102,7 @@ public class DeleteCommand extends Command {
                 return false;
             }
             DeleteCommand commandToCompare = (DeleteCommand) other;
-            if (this.targetId == null && this.targetIndices != null) { // only targetIndex present
+            if (this.targetId == null && this.targetIndices != null) { // only targetIndices present
                 return Arrays.equals(targetIndices, commandToCompare.targetIndices); // state check
             } else if (this.targetIndices == null && this.targetId != null) { // only targetId present
                 return targetId.equals(commandToCompare.targetId); // state check

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -57,7 +57,7 @@ public class DeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        if (targetIndices != null) { // index was used for the command
+        if (targetIndices != null) { // indices were used for the command
             int numberOfDeletions = 0;
             ArrayList<Person> personsToDelete = new ArrayList<>();
             for (Index currIndex : targetIndices) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -38,8 +38,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             deleteCommand = new DeleteCommand(id);
         } else { // supplied index only
             try {
-                Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
-                deleteCommand = new DeleteCommand(index);
+                String[] indexArray = argMultimap.getPreamble().split("\\s+");
+                Index[] indices = new Index[indexArray.length];
+                for (int i = 0; i < indexArray.length; i++) {
+                    indices[i] = ParserUtil.parseIndex(indexArray[i]);
+                }
+                deleteCommand = new DeleteCommand(indices);
             } catch (ParseException pe) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -38,12 +38,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             deleteCommand = new DeleteCommand(id);
         } else { // supplied index only
             try {
-                String[] indexArray = argMultimap.getPreamble().split("\\s+");
-                Index[] indices = new Index[indexArray.length];
-                for (int i = 0; i < indexArray.length; i++) {
-                    indices[i] = ParserUtil.parseIndex(indexArray[i]);
+                String[] arr = argMultimap.getPreamble().split("\\s+");
+                Index[] targetIndices = new Index[arr.length];
+                for (int i = 0; i < arr.length; i++) {
+                    targetIndices[i] = ParserUtil.parseIndex(arr[i]);
                 }
-                deleteCommand = new DeleteCommand(indices);
+                deleteCommand = new DeleteCommand(targetIndices);
             } catch (ParseException pe) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -29,7 +29,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(new Index[]{INDEX_FIRST_PERSON});
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -42,7 +42,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(new Index[]{outOfBoundIndex});
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -52,7 +52,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(new Index[]{INDEX_FIRST_PERSON});
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -71,21 +71,21 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(new Index[]{outOfBoundIndex});
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(new Index[]{INDEX_FIRST_PERSON});
+        DeleteCommand deleteSecondCommand = new DeleteCommand(new Index[]{INDEX_SECOND_PERSON});
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(new Index[]{INDEX_FIRST_PERSON});
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
@@ -41,7 +42,7 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        assertEquals(new DeleteCommand(new Index[]{INDEX_FIRST_PERSON}), command);
     }
 
     // TODO: Fix this testcase

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 
 /**
@@ -22,7 +23,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeleteCommand(new Index[]{INDEX_FIRST_PERSON}));
     }
 
     @Test


### PR DESCRIPTION
Implements support for multi delete by indices. Close #95.

A change was made to an attribute in DeleteCommand to support the implementation. In particular, the `Index` attribute `targetIndex` is now an `Index` array, `targetIndices` instead.

Also updated UG to reflect the change.

TODO: DG, testcases