### PR TITLE
Bug fixes in v1.4 from PED

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -88,7 +88,7 @@ Adds a student to TAPA.
 * An error message will be displayed to the user if the specified student ID already exists in TAPA.
 
     <div markdown="span" class="alert alert-info">:information_source:
-    **Note**: The name of the added `STUDENT_NAME` will be converted to Title Case.
+    **Note**: The name of the added student will be converted to Title Case.
     </div>
 
 **Example**:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -263,6 +263,10 @@ Assigns a task to a particular student.
 * `assign m/CS2103T tn/assignment 1`
     * Assigns assignment 1 to students taking module CS2103T.
 
+    <div markdown="span" class="alert alert-info">:information_source:
+    **Note**: The name of the assigned task will be converted to Title Case.
+    </div>
+
 <br>
 
 ### Viewing the completion status of a particular task: `progress`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -165,7 +165,7 @@ Marks a specific undone task as done for a particular student.
 
 **Example**:
 * `mark i/AXXXXXXXR idx/1`
-    * Marks the first undone task for the student with student ID AXXXXXXXR as done.
+    * Marks the first task in the task list for the student with student ID AXXXXXXXR as done.
 
 <br>
 
@@ -181,7 +181,7 @@ Marks a specific done task as undone for a particular student.
 
 **Example**:
 * `unmark i/AXXXXXXXR idx/1`
-    * Marks the first done task for the student with student ID AXXXXXXXR as undone.
+    * Marks the first task in the task list for the student with student ID AXXXXXXXR as undone.
 
 <br>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,6 +87,10 @@ Adds a student to TAPA.
 * The student's student ID (matriculation number) has to be unique.
 * An error message will be displayed to the user if the specified student ID already exists in TAPA.
 
+    <div markdown="span" class="alert alert-info">:information_source:
+    **Note**: The name of the added `STUDENT_NAME` will be converted to Title Case.
+    </div>
+
 **Example**:
 * `add i/AXXXXXXXR n/john m/CS2103T p/98765432 t/johnnn e/e0123456@u.nus.edu`
     * A student named John is added to TAPA.
@@ -263,7 +267,14 @@ Assigns a task to a particular student.
 * `assign m/CS2103T tn/assignment 1`
     * Assigns assignment 1 to students taking module CS2103T.
 
-    <div markdown="span" class="alert alert-info">:information_source:
+<div markdown="block" class="alert alert-info">
+> :warning: **Warning!:**
+
+<br>
+
+* As `MODULE_CODE` is case-sensitive, the user should ensure that the capitalisation of the module should be correct, or else the task would not be assigned properly.
+
+  <div markdown="span" class="alert alert-info">:information_source:
     **Note**: The name of the assigned task will be converted to Title Case.
     </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,8 +76,16 @@ Adds a student to TAPA.
 
 **Format**: `add i/STUDENT_ID n/STUDENT_NAME m/MODULE_CODE [p/PHONE_NUMBER] [t/TELEGRAM_HANDLE] [e/EMAIL_ADDRESS]​`
 
-* The student’s matriculation number, name as well as module code are compulsory fields.
+* The student’s student ID (matriculation number), name as well as module code are compulsory fields.
 * The phone number, telegram handle, and email address fields are optional and can be excluded.
+
+<div markdown="block" class="alert alert-info">
+> :warning: **Warning!:**
+
+<br>
+
+* The student's student ID (matriculation number) has to be unique.
+* An error message will be displayed to the user if the specified student ID already exists in TAPA.
 
 **Example**:
 * `add i/AXXXXXXXR n/john m/CS2103T p/98765432 t/johnnn e/e0123456@u.nus.edu`
@@ -320,7 +328,9 @@ Reverts the changes made by the previously executed command.
 **Format**: `undo`
 
 <div markdown="block" class="alert alert-info">
-**:warning: Warning!:**<br>
+> :warning: **Warning!:**
+
+<br>
 
 * The effects of the [`clear` command](https://ay2122s2-cs2103t-w09-4.github.io/tp/UserGuide.html#deleting-all-students-clear) and the [`undo` command](https://ay2122s2-cs2103t-w09-4.github.io/tp/UserGuide.html#undoing-the-previous-command-undo) cannot be undone!
 

--- a/src/main/java/seedu/address/commons/core/ManualMessages.java
+++ b/src/main/java/seedu/address/commons/core/ManualMessages.java
@@ -63,13 +63,13 @@ public class ManualMessages {
 
     public static final String MANUAL_MESSAGE_MARK_COMMAND = "Marks a specific undone task as done for a particular "
             + "student. \n"
-            + "Format : mark i/STUDENT_ID UNDONE_TASK_INDEX \n"
-            + "Example: mark i/A6942069R 1";
+            + "Format : mark i/STUDENT_ID idx/UNDONE_TASK_INDEX \n"
+            + "Example: mark i/A6942069R idx/1";
 
     public static final String MANUAL_MESSAGE_UNMARK_COMMAND = "Marks a specific done task as undone for a particular "
             + "student. \n"
-            + "Format : unmark i/STUDENT_ID DONE_TASK_INDEX \n"
-            + "Example: unmark i/A6942069R 1";
+            + "Format : unmark i/STUDENT_ID idx/DONE_TASK_INDEX \n"
+            + "Example: unmark i/A6942069R idx/1";
 
     public static final String MANUAL_MESSAGE_ARCHIVE_COMMAND = "Saves a copy of the details currently saved in the "
             + "address book into a separate file. \n"

--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -41,7 +41,7 @@ public class AssignCommand extends Command {
             + PREFIX_TASK_NAME + "assignment 1\n";
 
     public static final String MESSAGE_SUCCESS = "Task Assigned: %1$s";
-    public static final String MESSAGE_DUPLICATE_TASK = "This task is already assigned to all students.";
+    public static final String MESSAGE_DUPLICATE_TASK = "This task is already assigned to specified student(s).";
     public static final String MESSAGE_PERSON_NOT_FOUND = "There is no person with the given Student ID.";
     public static final String MODULE_CODE_NOT_FOUND = "There is no person taking the given module.";
 


### PR DESCRIPTION
List of Issues to implement bug fixes:
- [X] Missing Student ID Constraint from UG [#149](https://github.com/AY2122S2-CS2103T-W09-4/tp/issues/149)
Fix - Added warning for `add` command to warn users that student ID has to be a unique field in TAPA.
- [X] Incorrect manual for 'mark' and 'unmark' command [#155](https://github.com/AY2122S2-CS2103T-W09-4/tp/issues/155)
Fix - Include the prefixes for the tasks in `ManualMessages` for the `mark` and `unmark` commands.
- [X] Incorrect error message upon assigning duplicate tasks [#160](https://github.com/AY2122S2-CS2103T-W09-4/tp/issues/160)
Fix - Changed error message to imply task already assigned to one or multiple students.
- [X] First letter of task name forced to capitalise [#162](https://github.com/AY2122S2-CS2103T-W09-4/tp/issues/162)
Fix - Updated UserGuide to inform users that task name will be converted to Title Case.
- [X] Unexpected behavior with task_index in mark command [#167](https://github.com/AY2122S2-CS2103T-W09-4/tp/issues/167)
Fix - Updated the UserGuide to specify the index of the task list, and removed the implication of the use of a separate list for done and undone tasks.
