### PR TITLE
Fixed telegram handle format.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,8 +71,7 @@ Here are some example commands you can try:
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   Example: For the command `help`, if the user inputs `help help 123`, the input will be interpreted as `help`.
 
-* The parameter `TELEGRAM_HANDLE` should contain 5 to 32 characters. The characters can either be alphanumeric or underscore. However, the first and last character of the handle should not be an underscore.
-
+* The parameter `TELEGRAM_HANDLE` should contain 5 to 32 alphanumeric characters. The telegram handle cannot contain an underscore.
 </div>
 
 ### Adding a student: `add`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -71,7 +71,7 @@ Here are some example commands you can try:
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   Example: For the command `help`, if the user inputs `help help 123`, the input will be interpreted as `help`.
 
-* The parameter `TELEGRAM_HANDLE` should contain 5 to 32 alphanumeric characters. The telegram handle cannot contain an underscore.
+* The parameter `TELEGRAM_HANDLE` should contain 5 to 32 alphanumeric characters. The telegram handle cannot have any symbols (such as underscore) as well as whitespaces.
 </div>
 
 ### Adding a student: `add`

--- a/src/main/java/seedu/address/model/person/TelegramHandle.java
+++ b/src/main/java/seedu/address/model/person/TelegramHandle.java
@@ -8,10 +8,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class TelegramHandle {
     // Telegram handle has a limit of 5 to 32 characters excluding the @symbol at the front.
-    public static final String MESSAGE_CONSTRAINTS = "Telegram handles should contain 5 to 32 characters. "
-            + "The characters can either be alphanumeric characters or underscore. "
-            + "However, the handle cannot start or end with an underscore.";
-    public static final String VALIDATION_REGEX = "[a-zA-Z0-9][a-zA-Z0-9_]{3,30}[a-zA-Z0-9]";
+    public static final String MESSAGE_CONSTRAINTS = "Telegram handles should contain 5 to 32 alphanumeric characters.";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9]{5,32}";
 
     public final String telegramHandle;
 


### PR DESCRIPTION
Reverted changes made to telegram format in previous commits (Merge request #198).

Updated UG to include that telegram handle cannot have an underscore.