### PR TITLE
Fix bugs found in PE-D

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -113,7 +113,7 @@ Deletes a student from TAPA.
   * the specified index is a negative number
   * the specified index is larger than the number of students in TAPA
   * there is no student with the specified matriculation number
-* Multiple indices can be inputted in order to delete multiple students.
+* Multiple indices can be inputted in order to delete multiple students. All inputted indices must be valid in order for the command to execute successfully.
 
 **Example**:
 * `delete 10`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,6 +147,7 @@ Allows the user to look up the details of a particular student.
 **Format**: `find n/STUDENT_NAME` (or) `find i/STUDENT_ID` (or) `find m/MODULE_CODE`
 
 * The student whose name, student id or module code is specified after the `find` command will appear in the resulting list.
+* Search fields must be exact matches in order for the `find` command to display the result. For example, given a student John in TAPA, `find n/John` will successfully display this student but not `find n/Joh` or `find n/Jo`.
 
 **Example**:
 * `find n/John`

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,7 +27,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list "
             + "or Student ID.\n"
-            + "Parameters: INDEX (must be a positive integer) or i/STUDENT_ID\n"
+            + "Parameters: INDEX (must be a positive integer) " + "or " + PREFIX_ID + " STUDENT_ID\n"
             + "Example: " + COMMAND_WORD + " 1"
             + " or " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z\n";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,8 +27,10 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list "
             + "or Student ID.\n"
-            + "Parameters: INDEX (must be a positive integer) " + "or " + PREFIX_ID + " STUDENT_ID\n"
+            + "Multiple indices can be supplied, each separated by a whitespace, to delete multiple students.\n"
+            + "Parameters: INDEX (must be a positive integer, can have multiple) " + "or " + PREFIX_ID + "STUDENT_ID\n"
             + "Example: " + COMMAND_WORD + " 1"
+            + " or " + COMMAND_WORD + " 1 2 3 7"
             + " or " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z\n";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student:\n%1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,7 +27,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the student identified by the index number used in the displayed student list "
             + "or Student ID.\n"
-            + "Parameters: INDEX (must be a positive integer) or STUDENT_ID\n"
+            + "Parameters: INDEX (must be a positive integer) or i/STUDENT_ID\n"
             + "Example: " + COMMAND_WORD + " 1"
             + " or " + COMMAND_WORD + " " + PREFIX_ID + "A0123456Z\n";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -21,7 +21,7 @@ public class DeleteModuleCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes all students identified by the module code inputted.\n"
-            + "Parameters: m/MODULE_CODE\n"
+            + "Parameters: " + PREFIX_MODULE_CODE + " MODULE_CODE\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_MODULE_CODE + "CS2100\n";
 
     public static final String MESSAGE_DELETE_MULTIPLE_PERSONS_SUCCESS = "%s student(s) deleted.";

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -21,7 +21,7 @@ public class DeleteModuleCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes all students identified by the module code inputted.\n"
-            + "Parameters: " + PREFIX_MODULE_CODE + " MODULE_CODE\n"
+            + "Parameters: " + PREFIX_MODULE_CODE + "MODULE_CODE\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_MODULE_CODE + "CS2100\n";
 
     public static final String MESSAGE_DELETE_MULTIPLE_PERSONS_SUCCESS = "%s student(s) deleted.";

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -21,7 +21,7 @@ public class DeleteModuleCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes all students identified by the module code inputted.\n"
-            + "Parameters: MODULE_CODE\n"
+            + "Parameters: m/MODULE_CODE\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_MODULE_CODE + "CS2100\n";
 
     public static final String MESSAGE_DELETE_MULTIPLE_PERSONS_SUCCESS = "%s student(s) deleted.";


### PR DESCRIPTION
Fixes several bugs found in the PE-D. Closes #163, closes #169, closes #187.

Also added a line to the UG for the `delete` command to clarify that all indices must be valid for the command to execute successfully (in the case of multiple indices).