### PR TITLE
Fix formatting for glossary

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1257,7 +1257,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Mainstream OS**: Windows, Linux, Unix, OS-X
 * **Module**: A specific class that a student is taking
 * **Tag**: A category that the student belong to (usually denotes the module that is currently being taken)
-* **Person**: A student in TAPA. 
+* **Person**: A student in TAPA
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Appendix: Instructions for manual testing**


### PR DESCRIPTION
Current implementation looks like this:
![image](https://user-images.githubusercontent.com/65613207/162494628-4c36f142-d8d7-4a66-9051-e59e3b2cf980.png)
