### PR TITLE
Update glossary for DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1064,13 +1064,13 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-* 1a. A student with the same Student ID already exists.
+* 1a. A student with the same student ID already exists.
 
     * 1a1. TAPA shows an error message.
 
         Use case ends.
 
-* 1b. The Student ID of the student is not in the input command.
+* 1b. The student ID of the student is not in the input command.
 
     * 1b1. TAPA shows an error message.
 
@@ -1132,7 +1132,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes from step 2.
 
-* 3b. The given Student ID is invalid.
+* 3b. The given student ID is invalid.
 
     * 3b1. TAPA shows an error message.
 
@@ -1167,7 +1167,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes from step 2.
 
-* 3c. The new Student ID specified is already in the database.
+* 3c. The new student ID specified is already in the database.
 
     * 3c1. TAPA shows an error message.
 
@@ -1255,7 +1255,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-* 1a. The given Student ID is invalid.
+* 1a. The given student ID is invalid.
 
     * 1a1. TAPA shows an error message.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1391,7 +1391,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Module**: A specific class that a student is taking
 * **Tag**: A category that the student belong to (usually denotes the module that is currently being taken)
 * **Person**: A student in TAPA
-* **Student ID/Matriculation number**: Used interchangeable to refer to the unique identification number of a student
+* **Student ID/Matriculation number**: Used interchangeably to refer to the unique identification number of a student
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1391,6 +1391,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **Module**: A specific class that a student is taking
 * **Tag**: A category that the student belong to (usually denotes the module that is currently being taken)
 * **Person**: A student in TAPA
+* **Student ID/Matriculation number**: Used interchangeable to refer to the unique identification number of a student
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Updates the glossary to also include student ID/matriculation number as the terms are frequently used interchangeably.

Also changed instances of "Student ID" to "student ID" instead.