### PR TITLE
Remove guide section from DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -994,16 +994,6 @@ The `undo` command reverts the most recently executed command by restoring TAPA 
 
 --------------------------------------------------------------------------------------------------------------------
 
-## **Documentation, logging, testing, configuration, dev-ops**
-
-* [Documentation guide](Documentation.md)
-* [Testing guide](Testing.md)
-* [Logging guide](Logging.md)
-* [Configuration guide](Configuration.md)
-* [DevOps guide](DevOps.md)
-
---------------------------------------------------------------------------------------------------------------------
-
 ## **Appendix: Requirements**
 
 ### Product scope


### PR DESCRIPTION
After looking through the guides section labelled "Documentation, logging, testing, configuration, dev-ops" in the DG, they are more for educational purposes. As they are irrelevant to TAPA, this PR removes them from the DG. closes #285 